### PR TITLE
Remove guava dependency duplicated in webapp libs

### DIFF
--- a/components/org.wso2.carbon.healthcheck.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.healthcheck.api.endpoint/pom.xml
@@ -137,6 +137,14 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Proposed changes in this pull request
This is done for the CXF3 dependency upgrade effort. It removes guava jars that get packed unnecessarily inside the lib folder of webapps.