### PR TITLE
Add Error Log when the health check api fails

### DIFF
--- a/components/org.wso2.carbon.healthcheck.api.endpoint/src/main/java/org/wso2/carbon/healthcheck/api/endpoint/impl/HealthApiServiceImpl.java
+++ b/components/org.wso2.carbon.healthcheck.api.endpoint/src/main/java/org/wso2/carbon/healthcheck/api/endpoint/impl/HealthApiServiceImpl.java
@@ -44,6 +44,7 @@ public class HealthApiServiceImpl extends HealthApiService {
         List<HealthCheckError> errors = e.getErrors();
         ErrorsDTO errorsResponseDTO = new ErrorsDTO();
         errors.forEach(error -> {
+            log.error(error.getMessage());
             ErrorDTO errorDTO = new ErrorDTO();
             errorDTO.setMessage(error.getMessage());
             errorDTO.setDescription(error.getErrorDescription());

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,7 @@
         <apache.felix.scr.ds.annotations.version>1.2.8</apache.felix.scr.ds.annotations.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
         <version.equinox.osgi>3.9.1.v20130814-1242</version.equinox.osgi>
-        <carbon.kernel.version>4.5.0</carbon.kernel.version>
+        <carbon.kernel.version>4.6.3-m1</carbon.kernel.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
>  Fix https://github.com/wso2/product-is/issues/11749

```
TID: [-1234] Tenant: [carbon.super] [2021-05-16 11:09:35,751] [40607ae7-5121-4cb8-a2f1-ea2b5979a8ac]  : ERROR {org.wso2.carbon.healthcheck.api.endpoint.impl.HealthApiServiceImpl} - Active count of db connections exceeds the given limit. Active count: 50 for datasource: jdbc/WSO2IdentityDB
```