### PR TITLE
Add jdk 11 and 17 support along with spring framework removal

### DIFF
--- a/components/org.wso2.carbon.healthcheck.api.endpoint/pom.xml
+++ b/components/org.wso2.carbon.healthcheck.api.endpoint/pom.xml
@@ -154,11 +154,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
             <scope>provided</scope>
@@ -171,12 +166,11 @@
     </dependencies>
 
     <properties>
-        <build.helper.plugin.version>3.0.0</build.helper.plugin.version>
-        <org.codehaus.jackson.version>1.8.6</org.codehaus.jackson.version>
+        <build.helper.plugin.version>3.3.0</build.helper.plugin.version>
+        <org.codehaus.jackson.version>1.9.13</org.codehaus.jackson.version>
         <org.apache.cxf.version>3.3.7</org.apache.cxf.version>
-        <springframework.version>4.3.14.RELEASE</springframework.version>
         <jaxrx.jsr311.api.version>1.1.1</jaxrx.jsr311.api.version>
         <swagger.jaxrs.version>1.6.2</swagger.jaxrs.version>
-        <maven.war.plugin.version>2.2</maven.war.plugin.version>
+        <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     </properties>
 </project>

--- a/components/org.wso2.carbon.healthcheck.api.endpoint/src/main/webapp/WEB-INF/web.xml
+++ b/components/org.wso2.carbon.healthcheck.api.endpoint/src/main/webapp/WEB-INF/web.xml
@@ -6,26 +6,33 @@
 	http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" metadata-complete="true">
     <absolute-ordering />
 
-    <display-name>WSO2 Identity Server Identity Provider Management REST API</display-name>
-    <description>WSO2 Identity Server Identity Provider REST API</description>
-
-    <context-param>
-        <param-name>contextConfigLocation</param-name>
-        <param-value>WEB-INF/beans.xml</param-value>
-    </context-param>
-
-    <listener>
-        <listener-class>
-            org.springframework.web.context.ContextLoaderListener
-        </listener-class>
-    </listener>
+    <display-name>WSO2 APIM HEALTH CHECK REST API</display-name>
+    <description>WSO2 API Manager Health Check REST API</description>
 
     <servlet>
         <servlet-name>CXFServlet</servlet-name>
         <servlet-class>
-            org.apache.cxf.transport.servlet.CXFServlet
+            org.apache.cxf.jaxrs.servlet.CXFNonSpringJaxrsServlet
         </servlet-class>
         <load-on-startup>1</load-on-startup>
+        
+        <init-param>
+            <param-name>jaxrs.serviceClasses</param-name>
+            <param-value>
+                org.wso2.carbon.healthcheck.api.endpoint.HealthApi
+            </param-value>
+        </init-param>
+        <init-param>
+            <param-name>jaxrs.address</param-name>
+            <param-value>/</param-value>
+        </init-param>
+        <init-param>
+            <param-name>jaxrs.providers</param-name>
+            <param-value>
+                com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider,
+                org.wso2.carbon.healthcheck.api.endpoint.expmapper.HealthCheckEndpointExceptionMapper
+            </param-value>
+        </init-param>
     </servlet>
 
     <servlet-mapping>

--- a/pom.xml
+++ b/pom.xml
@@ -193,11 +193,6 @@
                 <version>${javax.ws.rs.api.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-web</artifactId>
-                <version>${springframework.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-frontend-jaxrs</artifactId>
                 <version>${org.apache.cxf.version}</version>
@@ -268,15 +263,14 @@
 
     <properties>
         <carbon.healthcheck.version>${project.version}</carbon.healthcheck.version>
-        <build.helper.plugin.version>3.0.0</build.helper.plugin.version>
-        <org.codehaus.jackson.version>1.8.6</org.codehaus.jackson.version>
+        <build.helper.plugin.version>3.3.0</build.helper.plugin.version>
+        <org.codehaus.jackson.version>1.9.13</org.codehaus.jackson.version>
         <jackson-databind.version>2.10.5.1</jackson-databind.version>
         <org.apache.cxf.version>3.3.7</org.apache.cxf.version>
-        <springframework.version>4.3.14.RELEASE</springframework.version>
         <javax.ws.rs.api.version>2.1.1</javax.ws.rs.api.version>
         <swagger.jaxrs.version>1.6.2</swagger.jaxrs.version>
-        <maven.war.plugin.version>2.2</maven.war.plugin.version>
-        <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
+        <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
+        <maven.buildnumber.plugin.version>3.2.0</maven.buildnumber.plugin.version>
         <apache.felix.scr.ds.annotations.version>1.2.8</apache.felix.scr.ds.annotations.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
         <version.equinox.osgi>3.9.1.v20130814-1242</version.equinox.osgi>
@@ -294,8 +288,8 @@
 
         <testng.version>6.3.1</testng.version>
         <powermock.version>1.6.6</powermock.version>
-        <jacoco.version>0.7.9</jacoco.version>
-        <maven.surefire.plugin.version>2.20</maven.surefire.plugin.version>
+        <jacoco.version>0.8.8</jacoco.version>
+        <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
     </properties>
 </project>


### PR DESCRIPTION
This pull request includes significant changes to the `org.wso2.carbon.healthcheck.api.endpoint` module, focusing on dependency updates and configuration modifications. The most important changes involve removing Spring dependencies, updating various plugin versions, and adjusting servlet configurations.

### Dependency and Plugin Updates:

* Removed `spring-web` dependency from `pom.xml` files. 
* Updated multiple plugin and library versions in the `pom.xml` files, including `build.helper.plugin`, `org.codehaus.jackson`, `maven.war.plugin`, and `jacoco`. 

### Configuration Changes:

* Modified `web.xml` to replace Spring-based servlet configuration with CXF JAX-RS configuration, including new init parameters for service classes and providers.

### Related Issues

1. https://github.com/wso2-enterprise/wso2-apim-internal/issues/7560
2. https://github.com/wso2-enterprise/wso2-apim-internal/issues/7739
3. https://github.com/wso2-enterprise/wso2-apim-internal/issues/7633